### PR TITLE
CHORE: ADD RAILS-CONTROLLER-TESTING TO GEMFILE

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,7 @@ group :development, :test do
   gem 'byebug'
   gem 'rspec-rails'
   gem 'capybara'
+  gem 'rails-controller-testing'
 end
 
 group :development do


### PR DESCRIPTION
CHORE: ADD RAILS-CONTROLLER-TESTING GEM TO GEMFILE

Issue: StaticController test resulted in following error.

![error](https://user-images.githubusercontent.com/58449380/106390651-67688480-63b7-11eb-9941-de3247897152.png)

[RSpec documentation](https://rspec.info/blog/2016/07/rspec-3-5-has-been-released/) suggests (in the `Rails: Support for Rails 5` section) either to add rails-controller-testing to gemfile of existing Rails applications or to write request specs instead of adding.

Reason: In Rails 5 assigns and assert_template are "soft deprecated". Controller tests themselves are not, and adding :type => :controller to your specs is still 100% supported. Through Rails 3 and 4 it was both prevalent and idiomatic to use assigns in controller specs. As this is a minor release of RSpec our commitment to SemVer means that we are not going to break your existing controller specs. For existing Rails applications that make heavy use of assigns adding the rails-controller-testing to your Gemfile will restore assigns and assert_template. RSpec integrates with this gem seamlessly, so your controller specs should just continue to work.

Current [Request spec](https://relishapp.com/rspec/rspec-rails/docs/request-specs/request-spec) documentation states that Capybara is not supported in request specs. Since Capybara is currently utilized in the static_controller_spec.rb and this is an existing Rails app, added RAILS-CONTROLLER-TESTING GEM TO GEMFILE